### PR TITLE
【DRAFT】CFPページの実装

### DIFF
--- a/pages/call-for-proposals/index.vue
+++ b/pages/call-for-proposals/index.vue
@@ -1,16 +1,117 @@
 <i18n lang="yaml">
+# TODO 日付を修正する
+# TODO フォームのリンクを修正する
+# TODO その他、必要に応じて文言を修正する（応募要項、事前録画の有無など）
 en:
-  title: 'call-for-proposals en'
+  title: Submit your talks for ScalaMatsuri 2023!
+  section1_body: |
+    We are excited to announce that ScalaMatsuri will be held on April 15th (Saturday), and April 16th (Sunday). Please submit your talk for the general sessions.<br/><br/>
+    The CFP will close at January 14th (Saturday), 2023 23:59 <a href="https://time.is/en/Anywhere%20on%20Earth">Anywhere on Earth</a> (or Jan 15th 20:59 JST).
+    <br/><br/>
+    We're considering pre-recording talks for those who might find it difficult to give the talk live due to the timezone. If you wish to pre-record your talk, please let us know in the CFP.<br/>
+    We're not planning on providing dubbed track for the prerecordings; however, some sessions will be translated at real time by  professional interpreters.
+    <br/><br/>
+    Matsuri, meaning festival, is about time and space out of the everyday.<br>
+    It’s about mustering up the courage to do something cool (even though we are normally shy).<br>
+    We want to make it a fun experience, regardless of gender, race, and many different backgrounds.<br>
+    All participants, including speakers and sponsors, are asked to be respectful to each other and follow the <a href="%{coc_link}" target="_blank" rel="noopener"><span>code of conduct</span></a>.<br><br>
+    As one of largest international Scala conferences in Asia, we want to make it a fun event for both the domestic audience and those visiting Japan from overseas.
+  section2_title: Speaker selection process
+  section2_body: |
+    ScalaMatsuri organizers will curate the talks using the result as a reference.
+  section3_title: Application
+  section3_body: <ul>
+    <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSfkaOCQGpMTosQIjOXm6jpUbaf8jk7QK0SKvbBR61xSjTPQbg/viewform">Submit my talk</a></li>
+    <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSc8qLfXH2aS1jTxN88qyxKS4iwiCmyGAcwfCFyox7q0BzNp8g/closedform">Add another speaker</a></li>
+    </ul>
+  section4_title: Application details
+  section4_body: |
+    <ul class="section_note">
+      <li class="section_note_item">Any topic that might be of interest to Scala learners and Scala community members are welcome, including beginner tutorials, favorite technique, and case studies.</li>
+      <li class="section_note_item">The session length is 20 min. We will allow 40 min as exception, but will likely accept 20 min talks mainly for 2023 edition</li>
+      <li class="section_note_item">The format may be the regular lecture format.</li>
+      <li class="section_note_item">The talk must be in either English or Japanese. All slides must be in English. Note that we will prepare Japanese subtitles.</li>
+      <li class="section_note_item">The abstract must be 300 characters or fewer. We might ask for a longer overview once your talk is accepted.</li>
+      <li class="section_note_item">You are allowed up to 3 submissions.</li>
+      <li class="section_note_item">Please note that if you exceed any of the limits, the staff may edit your submissions at our discretion.</li>
+      <li class="section_note_item">We're not planning on providing dubbed translation track for the prerecordings.</li>
+    </ul>
+    Note again that ScalaMatsuri organizers will need to prepare the subtitles, so you are asked to submit the slides weeks in advance.
 ja:
-  title: 'call-for-proposals ja'
+  title: "ScalaMatsuriで話を聞かせてください！"
+  section1_body: |
+    2023年04月15日(土)、16日(日)にScalaMatsuri 2023を開催します。<br/>
+    そこで、ScalaMatsuri 2023の一般セッションの応募を開始します。<br/><br/><br/>
+    締切は2023年1月14日(土) 23:59 <a href="https://time.is/ja/Anywhere%20on%20Earth">Anywhere on Earth</a> (1月15日 20:59 JST)を予定しています。<br/><br/>
+    今回も時差の関係で当日発表が難しい方のために、事前録画による登壇を検討しております。事前録画による登壇を希望する人はCFP応募時点でお伝えください。<br/>
+    一部セッションにはプロによる日英同時通訳がつきますが、事前録画には吹き替え録音などは提供しない予定です。<br/><br/>
+    「Matsuri」はハレの日、つまり非日常の時と空間です。<br/>
+    (普段はシャイでも) ちょっと勇気を出してちょっとカッコいいことをやってみたい。<br/>
+    性別や人種など多様な背景を持つ人々が互いに敬意を払って楽しい時間を過ごせるよう、当カンファレンスでは発表者や参加者、スポンサーの皆さんに<a href="%{coc_link}" target="_blank" rel="noopener"><span>行動規範</span></a>を守っていただくようにお願いしています。<br/>
+    アジア最大規模の国際的なイベントとして、日本国内だけではなく、海外からの参加者にも楽しめるイベントにしたいと考えています。<br/>
+  section2_title: "講演者の決定"
+  section2_body: |
+    アンケート結果を参考に、ScalaMatsuri 2023運営にて選考会を開催し講演者を決定します。<br/>
+  section3_title: "応募"
+  section3_body: |
+    <ul>
+      <li><a href="https://docs.google.com/forms/d/1WQYtCrvfjnjUAQ79VWE8-gJgsUkxHcr7uyBL1R4cwhA/viewform?edit_requested=true">セッション応募フォーム</a></li>
+      <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSc8qLfXH2aS1jTxN88qyxKS4iwiCmyGAcwfCFyox7q0BzNp8g/closedform">追加講演者登録フォーム</a></li>
+    </ul>
+  section4_title: "応募要項"
+  section4_body: |
+    <ul class="section_note">
+      <li class="section_note_item">内容は、Scala ビギナー もしくは Scala コミュニティが興味があると思うトピックであれば自由です。</li>
+      <li class="section_note_item">講演の時間は20分枠となります。40分枠もございますが、今回は20分枠が中心のイベントになります。</li>
+      <li class="section_note_item">講演は通常の一人が聴衆に対して喋る講義形式でお願いします。</li>
+      <li class="section_note_item">話す言語は、英語もしくは日本語です。スライド本文は英語で、日本語の字幕つけをお願いしています。</li>
+      <li class="section_note_item">提出には、日本語で200字以内の概要、または300字以内の英語の概要が必要です。<br/>(採択後に、あらためて長めの概要の提出をお願いする場合があります。)</li>
+      <li class="section_note_item">1人3セッションまで応募していただけます。</li>
+      <li class="section_note_item">各種制限を超えている場合など、運営の判断で掲載内容を若干修正する場合があります。予めご了承ください。</li>
+      <li class="section_note_item">事前録画には吹き替え録音などは提供しない予定です。</li>
+    </ul>
+    <br/>
+    概要、スライド等の英語につきましては、運営のベストエフォートでレビューをしています。
 </i18n>
 
 <template>
   <MainVisual :title="t('title')" />
-  {{ $route.fullPath }}
+  <div class="section">
+  <p class="section_text">
+    <span v-html="t('section1_body', { coc_link: localePath('code-of-conduct') })" />
+  </p>
+  </div>
+  <div class="section">
+    <h2 class="section_title">
+      <span class="section_title_inner">{{ t("section2_title") }}</span>
+    </h2>
+    <p class="section_text">
+      <span v-html="t('section2_body')" />
+    </p>
+  </div>
+  <div class="section">
+    <h2 class="section_title">
+      <span class="section_title_inner">{{ t("section3_title") }}</span>
+    </h2>
+    <p class="section_text">
+      <span v-html="t('section3_body')" />
+    </p>
+  </div>
+  <div class="section">
+    <h2 class="section_title">
+      <span class="section_title_inner">{{ t("section4_title") }}</span>
+    </h2>
+    <p class="section_text">
+      <span v-html="t('section4_body')" />
+    </p>
+    <p class="section_text">
+      <br />
+    </p>
+  </div>
 </template>
 
 <script setup lang="ts">
 const { t } = useI18n()
+const localePath = useLocalePath()
 publichedCheck()
 </script>


### PR DESCRIPTION
closes #12 

- 実装とテキストを2023年から移植
- 未確定の部分があるため文章は未修正（TODOコメント化）

## スクリーンショット

![2023-12-04 22 25 22 localhost 2d67d5c15c0a](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/42737560/ccdb7c22-e862-42e6-a746-a571befa24f2)
![2023-12-04 22 25 29 localhost 4b6d5fe97322](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/42737560/4574459e-47c2-4c95-9b93-844edbccdb3d)
