### PR TITLE
モバイルビューのバナーが壊れている + モバイルビューでロゴのブレークポイントがおかしいのを直す

### DIFF
--- a/components/MainVisual.vue
+++ b/components/MainVisual.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main">
     <div class="main_inner">
-      <h1 class="main__title">
+      <h1 class="main_title">
         {{ title }}
       </h1>
     </div>

--- a/components/MainVisual.vue
+++ b/components/MainVisual.vue
@@ -31,5 +31,6 @@ const { title } = defineProps({
   font-weight: bold;
   letter-spacing: 0.05em;
   line-height: 68px;
+  word-break: auto-phrase;
 }
 </style>

--- a/components/top/Banners.vue
+++ b/components/top/Banners.vue
@@ -47,6 +47,7 @@ const { locale, t } = useI18n()
   max-width: 834px;
   margin-top: 20px;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
 }
 // NOTE: バナー1つのとき
@@ -57,10 +58,9 @@ const { locale, t } = useI18n()
 }
 // NOTE: バナー2つのとき
 .banner_item_two {
-  width: calc(50% - 10px);
 }
 .banner_item {
-  display: block;
+  flex: 20rem;
   height: 88px;
   color: #fff;
   font-weight: bold;
@@ -71,6 +71,8 @@ const { locale, t } = useI18n()
   text-align: center;
   position: relative;
   padding: 17px 0;
+  margin-left: 12px;
+  margin-right: 12px;
   &:after {
     content: '';
     width: 18px;
@@ -88,6 +90,7 @@ const { locale, t } = useI18n()
     display: inline-block;
     height: 54px;
     line-height: 54px;
+    color: #fff;
   }
   &-sponsor {
     background-color: #e4ae2f;

--- a/components/top/MainVisual.vue
+++ b/components/top/MainVisual.vue
@@ -158,6 +158,7 @@ const shuffledShogunSponsors = computed(() => arrayShuffle(shogunSponsors.value)
     padding: 5vh;
     font-size: 5vh;
     text-shadow: 1px 2px 3px #560808;
+    word-break: auto-phrase;
     & > .title--pc {
       display: none;
     }


### PR DESCRIPTION
close https://github.com/scalamatsuri/2024.scalamatsuri.org/issues/67

- [x] `word-break: auto-phrase;`を利用してタイトルのブレークポイント崩れを修正
- [x] バナーの文字崩れを修正
- [x] 偶然壊れてそうなクラス名を修正

### broken banners

![image](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/1113940/d780f4e1-76cc-4abe-a552-a3201da9fa85)

### fixed banners

![image](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/1113940/9a33b96a-803b-4080-96e5-403c99d37207)

### original PC

![image](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/1113940/b043bb5a-c014-4b2e-af5f-37d1fcb816ad)

### fixed PC

![image](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/1113940/5f8c0c3e-cab4-4a09-8169-4a8efede30ca)
