### PR TITLE
横幅が狭いときにバナーテキストがはみださないようバナーリストを縦並びにする

### DIFF
--- a/components/top/Banners.vue
+++ b/components/top/Banners.vue
@@ -59,6 +59,17 @@ const { locale, t } = useI18n()
 .banner_item_two {
   width: calc(50% - 10px);
 }
+
+@media screen and (max-width: 800px) {
+  .banner_list {
+    flex-direction: column;
+  }
+  .banner_item_two {
+    width: calc(100% - 20px);
+    margin: 10px;
+  }
+}
+
 .banner_item {
   display: block;
   height: 88px;


### PR DESCRIPTION
Part of #67


https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/127635/49f45475-3ebc-488e-8236-d61485643184

