### PR TITLE
将軍スポンサーのタイトルだけ大きくなるよう修正＆スポンサーロゴを2列で表示するように修正

### DIFF
--- a/components/top/Sponsors.vue
+++ b/components/top/Sponsors.vue
@@ -174,7 +174,7 @@ const shuffledBugyos = computed(() => arrayShuffle(bugyos.value))
     -webkit-text-fill-color: transparent;
   }
   &-tairou {
-    font-size: 4em;
+    font-size: 3em;
     color: #ee892c;
   }
   &-daimyo {
@@ -217,8 +217,8 @@ const shuffledBugyos = computed(() => arrayShuffle(bugyos.value))
 }
 .sponsors_item {
   padding: 0 10px;
-  width: 33%;
-  max-width: 242px;
+  width: 50%;
+  max-width: 50%;
   margin-top: 20px;
   img {
     width: 100%;

--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -14,20 +14,6 @@
     "slide_html": ""
   },
   {
-    "id": "SHOGUN_2",
-    "type": "SHOGUN",
-    "ja": {
-      "name": "株式会社COMPASS"
-    },
-    "en": {
-      "name": "COMPASS Inc"
-    },
-    "logo": "/img/sponsors/qubena.png",
-    "url": "https://qubena.com/",
-    "text_html": "",
-    "slide_html": ""
-  },
-  {
     "id": "DAIMYO_1",
     "type": "DAIMYO",
     "ja": {

--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -14,6 +14,20 @@
     "slide_html": ""
   },
   {
+    "id": "SHOGUN_2",
+    "type": "SHOGUN",
+    "ja": {
+      "name": "株式会社COMPASS"
+    },
+    "en": {
+      "name": "COMPASS Inc"
+    },
+    "logo": "/img/sponsors/qubena.png",
+    "url": "https://qubena.com/",
+    "text_html": "",
+    "slide_html": ""
+  },
+  {
     "id": "DAIMYO_1",
     "type": "DAIMYO",
     "ja": {


### PR DESCRIPTION
スマホ表示で気になっていた点の修正

旧：
<img width="639" alt="image" src="https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/4135267/2c129f3e-cf12-4dbd-ba4d-cf658fe0c30d">

新：
<img width="638" alt="image" src="https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/4135267/ab36b8e3-ff08-4a3a-8bcc-55a925d20951">
