### PR TITLE
nuxt generateでSSG相当の実施を行い、SEO等に対応出来るようにする

### DIFF
--- a/components/top/Sponsors.vue
+++ b/components/top/Sponsors.vue
@@ -49,87 +49,101 @@ ja:
       </p>
       <h3 class="sponsors_title sponsors_subtitle-syogun">{{ t('syogun') }}</h3>
       <ul class="sponsors_list">
-        <li v-for="sponsor in shuffledShoguns" :key="sponsor.logo" class="sponsors_item">
-          <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
-          <div v-if="locale == `en`">
-            <p>{{ sponsor.en.name }}</p>
-          </div>
-          <div v-if="locale == `ja`">
-            <p>{{ sponsor.ja.name }}</p>
-          </div>
-        </li>
+        <ClientOnly>
+          <li v-for="sponsor in shuffledShoguns" :key="sponsor.logo" class="sponsors_item">
+            <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
+            <div v-if="locale == `en`">
+              <p>{{ sponsor.en.name }}</p>
+            </div>
+            <div v-if="locale == `ja`">
+              <p>{{ sponsor.ja.name }}</p>
+            </div>
+          </li>
+        </ClientOnly>
       </ul>
       <h3 class="sponsors_title sponsors_subtitle-tairou">{{ t('tairou') }}</h3>
       <ul class="sponsors_list">
-        <li v-for="sponsor in shuffledTairous" :key="sponsor.logo" class="sponsors_item">
-          <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
-          <div v-if="locale == `en`">
-            <p>{{ sponsor.en.name }}</p>
-          </div>
-          <div v-if="locale == `ja`">
-            <p>{{ sponsor.ja.name }}</p>
-          </div>
-        </li>
+        <ClientOnly>
+          <li v-for="sponsor in shuffledTairous" :key="sponsor.logo" class="sponsors_item">
+            <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
+            <div v-if="locale == `en`">
+              <p>{{ sponsor.en.name }}</p>
+            </div>
+            <div v-if="locale == `ja`">
+              <p>{{ sponsor.ja.name }}</p>
+            </div>
+          </li>
+        </ClientOnly>
       </ul>
       <h3 class="sponsors_title sponsors_subtitle-daimyo">{{ t('daimyo') }}</h3>
       <ul class="sponsors_list">
-        <li v-for="sponsor in shuffledDaimyos" :key="sponsor.logo" class="sponsors_item">
-          <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
-          <div v-if="locale == `en`">
-            <p>{{ sponsor.en.name }}</p>
-          </div>
-          <div v-if="locale == `ja`">
-            <p>{{ sponsor.ja.name }}</p>
-          </div>
-        </li>
+        <ClientOnly>
+          <li v-for="sponsor in shuffledDaimyos" :key="sponsor.logo" class="sponsors_item">
+            <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
+            <div v-if="locale == `en`">
+              <p>{{ sponsor.en.name }}</p>
+            </div>
+            <div v-if="locale == `ja`">
+              <p>{{ sponsor.ja.name }}</p>
+            </div>
+          </li>
+        </ClientOnly>
       </ul>
       <h3 class="sponsors_title sponsors_subtitle-samurai">{{ t('samurai') }}</h3>
       <ul class="sponsors_list">
-        <li v-for="sponsor in shuffledSamurais" :key="sponsor.logo" class="sponsors_item">
-          <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
-          <div v-if="locale == `en`">
-            <p>{{ sponsor.en.name }}</p>
-          </div>
-          <div v-if="locale == `ja`">
-            <p>{{ sponsor.ja.name }}</p>
-          </div>
-        </li>
+        <ClientOnly>
+          <li v-for="sponsor in shuffledSamurais" :key="sponsor.logo" class="sponsors_item">
+            <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
+            <div v-if="locale == `en`">
+              <p>{{ sponsor.en.name }}</p>
+            </div>
+            <div v-if="locale == `ja`">
+              <p>{{ sponsor.ja.name }}</p>
+            </div>
+          </li>
+        </ClientOnly>
       </ul>
       <h3 class="sponsors_title sponsors_subtitle-utage">{{ t('utage') }}</h3>
       <ul class="sponsors_list">
-        <li v-for="sponsor in shuffledUtages" :key="sponsor.logo" class="sponsors_item">
-          <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
-          <div v-if="locale == `en`">
-            <p>{{ sponsor.en.name }}</p>
-          </div>
-          <div v-if="locale == `ja`">
-            <p>{{ sponsor.ja.name }}</p>
-          </div>
-        </li>
+        <ClientOnly>
+          <li v-for="sponsor in shuffledUtages" :key="sponsor.logo" class="sponsors_item">
+            <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
+            <div v-if="locale == `en`">
+              <p>{{ sponsor.en.name }}</p>
+            </div>
+            <div v-if="locale == `ja`">
+              <p>{{ sponsor.ja.name }}</p>
+            </div>
+          </li>
+        </ClientOnly>
       </ul>
       <h3 class="sponsors_title sponsors_subtitle-ninja">{{ t('ninja') }}</h3>
       <ul class="sponsors_list">
-        <li v-for="sponsor in shuffledNinjas" :key="sponsor.logo" class="sponsors_item-ninja">
-          <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
-          <div v-if="locale == `en`">
-            <p>{{ sponsor.en.name }}</p>
-          </div>
-          <div v-if="locale == `ja`">
-            <p>{{ sponsor.ja.name }}</p>
-          </div>
-        </li>
+        <ClientOnly>
+          <li v-for="sponsor in shuffledNinjas" :key="sponsor.logo" class="sponsors_item-ninja">
+            <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
+            <div v-if="locale == `en`">
+              <p>{{ sponsor.en.name }}</p>
+            </div>
+            <div v-if="locale == `ja`">
+              <p>{{ sponsor.ja.name }}</p>
+            </div>
+          </li>
+        </ClientOnly>
       </ul>
       <h3 class="sponsors_title sponsors_subtitle-bugyo">{{ t('bugyo') }}</h3>
       <ul class="sponsors_list">
-        <li v-for="sponsor in shuffledBugyos" :key="sponsor.logo" class="sponsors_item">
-          <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
-          <div v-if="locale == `en`">
-            <p>{{ sponsor.en.name }}</p>
-          </div>
-          <div v-if="locale == `ja`">
-            <p>{{ sponsor.ja.name }}</p>
-          </div>
-        </li>
+        <ClientOnly>
+          <li v-for="sponsor in shuffledBugyos" :key="sponsor.logo" class="sponsors_item">
+            <a :href="sponsor.url" target="_blank"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
+            <div v-if="locale == `en`">
+              <p>{{ sponsor.en.name }}</p>
+            </div>
+            <div v-if="locale == `ja`">
+              <p>{{ sponsor.ja.name }}</p>
+            </div>
+          </li>
+        </ClientOnly>
       </ul>
     </div>
   </section>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,13 @@
 export default defineNuxtConfig({
-  ssr: false,
+  // SEO目的でCSRではなくSSG相当とするため、ssr=trueとすることでnext generateで各種ページを生成させる
+  ssr: true,
+  nitro: {
+    prerender: {
+      // @nuxtjs/i18n を入れている影響でnuxt generateのroot page生成が500となるためfalseを指定
+      // 本番環境ではfirebase hosting側で301としているため該当ページは不要
+      failOnError: false,
+    },
+  },
   css: ['~/assets/vendor/sanitize.css/sanitize.css', '~/assets/scss/main.scss'],
   vite: {
     css: {


### PR DESCRIPTION
closes https://github.com/scalamatsuri/2024.scalamatsuri.org/issues/61

<img width="502" alt="image" src="https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/915731/3b4cb5b4-774e-4562-adcf-b83e5bfe79d5">

以下のように各種tagなどが生成されている

https://krrrr38-scalamatsuri2024.firebaseapp.com/en/sponsors

```sh
> curl -s https://krrrr38-scalamatsuri2024.firebaseapp.com/en/sponsors/ | head -20
<!DOCTYPE html><html><head><meta charset="UTF-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<title>Sponsors | ScalaMatsuri 2024</title>
<meta http-equiv="x-ua-compatible" content="ie=edge">
<meta name="description" content="ScalaMatsuri 2024 | The largest international Scala conference in Asia">
<meta name="keywords" content="Scala,スカラ,カンファレンス,ScalaMatsuri,2024">
<meta property="og:type" content="website">
<meta property="og:locale" content="ja_JP">
<meta property="og:url" content="https://scalamatsuri.org/">
<meta property="og:title" content="ScalaMatsuri 2024 | The largest international Scala conference in Asia">
<meta property="og:site_name" content="ScalaMatsuri 2024">
<meta property="og:description" content="The largest international Scala conference in Asia.">
<meta property="og:image" content="https://2024.scalamatsuri.org/img/favicons/ogp.png">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="630">
<meta name="twitter:card" content="summary_large_image">
<meta name="twitter:site" content="'scala_jp'">
<meta name="twitter:creator" content="'scala_jp'">
<meta name="twitter:url" content="https://twitter.com/scala_jp">
<meta name="twitter:title" content="ScalaMatsuri 2024 | The largest international Scala conference in Asia">
```