### PR TITLE
スタッフページのロゴとデータのズレを解消

### DIFF
--- a/pages/staff/index.vue
+++ b/pages/staff/index.vue
@@ -7,15 +7,17 @@ ja:
 
 <template>
   <MainVisual :title="t('title')" />
-  <div id="staff">
-    <!-- スタッフ ここから -->
-    <div class="staff">
-      <ul class="staff_list">
-        <StaffListItem v-for="staff in shuffledStaffs" :key="staff.index" :staff="staff" class="staff_item" />
-      </ul>
+  <ClientOnly>
+    <div id="staff">
+      <!-- スタッフ ここから -->
+      <div class="staff">
+        <ul class="staff_list">
+          <StaffListItem v-for="staff in shuffledStaffs" :key="staff.index" :staff="staff" class="staff_item" />
+        </ul>
+      </div>
+      <!-- スタッフ ここまで -->
     </div>
-    <!-- スタッフ ここまで -->
-  </div>
+  </ClientOnly>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
https://scalamatsuri.org/en/staff
↑のページのスタッフ名とロゴがずれていたので、<ClientOnly> タグで囲って修正しました。