### PR TITLE
CFP募集が終わったのでトップページのリンクを消す

### DIFF
--- a/components/top/Banners.vue
+++ b/components/top/Banners.vue
@@ -16,9 +16,11 @@ ja:
       <nuxt-link :to="localePath('sponsorship')" class="banner_item banner_item-sponsor">
         <span>{{ t('sponsorship') }} </span>
       </nuxt-link>
+      <!--
       <nuxt-link :to="localePath('call-for-proposals')" class="banner_item banner_item-session">
         <span>{{ t('call-for-proposals') }}</span>
       </nuxt-link>
+      -->
       <a href="https://scalaconfjp.doorkeeper.jp/events/168847" target="_blank" class="banner_item banner_item-ticket">
         <span>{{ t('ticket') }}</span>
       </a>


### PR DESCRIPTION
CFP募集が終了したので、トップページの登壇募集のリンクを削除します

## preview

![image](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/1401147/bbad02a6-72b3-4580-81f4-c3138ff01c95)
