### PR TITLE
Fix timezone to Asia/Tokyo

### DIFF
--- a/composables/common.ts
+++ b/composables/common.ts
@@ -7,16 +7,16 @@ export const arrayShuffle = (array: any[]) => {
   return array
 }
 
-const zeroPadding = (num: number) => {
-  return num.toString().padStart(2, '0')
-}
-
+const locale: Intl.LocalesArgument = 'en-US'
+const timeZone = 'Asia/Tokyo'
 export const displayHour = (datetimeString: string) => {
   const d = new Date(datetimeString)
-  return `${zeroPadding(d.getHours())}:${zeroPadding(d.getMinutes())}`
+  return d.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit', hour12: false, timeZone })
 }
 
 export const displayDateAndHour = (datetimeString: string) => {
   const d = new Date(datetimeString)
-  return `${zeroPadding(d.getMonth() + 1)}/${zeroPadding(d.getDate())} ${displayHour(datetimeString)}`
+  const date = d.toLocaleDateString(locale, { month: '2-digit', day: '2-digit', timeZone })
+  const time = d.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit', hour12: false, timeZone })
+  return `${date} ${time}`
 }


### PR DESCRIPTION
fix https://github.com/scalamatsuri/2024.scalamatsuri.org/issues/231

- プログラム上でのタイムゾーン表示はGMT+9がベタ書きされている
- しかし日時表示はタイムゾーンによって表示が切り替わるような実装になっていた
- そのため、GMT+9 以外のシステムでプログラムを表示すると、GMT+9と書いているにもかかわらず、異なるタイムゾーンでの時間表示がされていた。
- プログラムはすべてオフラインで開催されるため、タイムゾーンを考慮して時間表示する必要はない
- すべて Asia/Tokyo での日時で表示するようにした

|タイムゾーン設定|プログラム表示|
|---|---|
| ![Screenshot_20240411-185036](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/9353584/e26e4938-546d-4608-a420-2985ebf7fb1b) | ![Screenshot_20240412-034936](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/9353584/bc930664-3a8f-4eaa-9076-5cfe6bf4ccff) |
| ![Screenshot_20240412-034921](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/9353584/3807dddc-3b73-4e37-a9c6-920d756522fe) |  ![Screenshot_20240412-034936](https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/9353584/bc930664-3a8f-4eaa-9076-5cfe6bf4ccff) |

タイムゾーンどこに設定しても表示変わってなさそうでよし?
