### PR TITLE
チケット販売リンクを一時閉じる対応

### DIFF
--- a/pages/training-day/index.vue
+++ b/pages/training-day/index.vue
@@ -59,14 +59,17 @@
     <h2 class="section_title">
       <span class="section_title_inner">チケット</span>
     </h2>
-    <p class="section_text">チケットは下記よりお求めください。</p>
+    <br />
+    <br />
+    <p>現在、トレーニング・デイのチケット販売時期を調整中です。今しばらくお待ち下さい。</p>
+    <!-- <p class="section_text">チケットは下記よりお求めください。</p>
     <div class="banner">
       <div class="banner_list">
         <a href="https://scalaconfjp.doorkeeper.jp/events/169208" target="_blank" class="banner_item banner_item-ticket">
           <span>トレーニング・デイ</span>
         </a>
       </div>
-    </div>
+    </div> -->
   </div>
 </template>
 


### PR DESCRIPTION
チケット販売まだできてなかったので、一時的に閉じました。

<img width="1502" alt="image" src="https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/4135267/34ec8478-48ba-4c44-8f54-c79a27080ed8">
