### PR TITLE
MainVisual のロゴと、テキストのずれ修正

### DIFF
--- a/components/top/MainVisual.vue
+++ b/components/top/MainVisual.vue
@@ -10,31 +10,33 @@ ja:
 </i18n>
 
 <template>
-  <main class="main">
-    <div class="main_inner">
-      <div class="main__container">
-        <h1 class="main__title">
-          ScalaMatsuri {{ year }}
-          <p class="main__title-sub">{{ t('alt') }}</p>
-          <p class="main__title-sub">{{ t('date') }}</p>
-          <p class="main__title-sub">{{ t('venue') }}</p>
-        </h1>
+  <ClientOnly>
+    <main class="main">
+      <div class="main_inner">
+        <div class="main__container">
+          <h1 class="main__title">
+            ScalaMatsuri {{ year }}
+            <p class="main__title-sub">{{ t('alt') }}</p>
+            <p class="main__title-sub">{{ t('date') }}</p>
+            <p class="main__title-sub">{{ t('venue') }}</p>
+          </h1>
+        </div>
+        <div class="main_sponsor">
+          <ul class="main_sponsor_inner">
+            <li v-for="sponsor in shuffledShogunSponsors" :key="sponsor.logo" class="main_sponsor_item">
+              <a :href="sponsor.url"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
+              <div v-if="locale == `en`">
+                <p>{{ sponsor.en.name }}</p>
+              </div>
+              <div v-if="locale == `ja`">
+                <p>{{ sponsor.ja.name }}</p>
+              </div>
+            </li>
+          </ul>
+        </div>
       </div>
-      <div class="main_sponsor">
-        <ul class="main_sponsor_inner">
-          <li v-for="sponsor in shuffledShogunSponsors" :key="sponsor.logo" class="main_sponsor_item">
-            <a :href="sponsor.url"><img :src="sponsor.logo" :alt="sponsor.en.name" /></a>
-            <div v-if="locale == `en`">
-              <p>{{ sponsor.en.name }}</p>
-            </div>
-            <div v-if="locale == `ja`">
-              <p>{{ sponsor.ja.name }}</p>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </main>
+    </main>
+  </ClientOnly>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
将軍スポンサーのロゴとテキストがズレる問題の対応。

ClientOnly で囲むことで対応しました。

ローカルでずれないことを確認済みです。