### PR TITLE
News のURLで除外設定できるように実装

### DIFF
--- a/components/top/News.vue
+++ b/components/top/News.vue
@@ -29,7 +29,11 @@ const blogDomain = {
 const { data: postsXmlStr } = await useFetch<Blob>(`https://${blogDomain}/rss/category/${category}`)
 const body = await postsXmlStr.value?.text()
 const converted = xmlConverter.xml2js(body, { compact: true })
-const posts = [].concat(converted.rss.channel.item || [])
+
+const ignore_news_urls = [
+  'https://blog.scalamatsuri.org/entry/2024/01/26/135742',
+]
+const posts = [].concat(converted.rss.channel.item || []).filter((post: any) => !ignore_news_urls.includes(post.link._text))
 
 const currentPostIdx = useState<number>('currentPostIdx', () => 0)
 let updatePostInterval: NodeJS.Timeout | undefined


### PR DESCRIPTION
https://scalamatsuri.slack.com/archives/CBUJ2C004/p1717491013826689

スポンサー募集のブログは表示しないように、filter しました。
(暫定対応っぽくなっちゃいますがとりあえず、ローカルででなくなることを確認しました。)


https://github.com/scalamatsuri/2024.scalamatsuri.org/assets/3018584/71620279-122e-4c42-8877-19a4ea8d0bdd



