### PR TITLE
Fix twitter link for @rlemaitre_com

### DIFF
--- a/data/speakers.json
+++ b/data/speakers.json
@@ -276,7 +276,7 @@
     "iconUrl": "https://rlemaitre.com/images/rlemaitre.jpeg",
     "contributes": ["I maintains pillars (https://pillars.rlemaitre.com) and contribute to Iron (https://github.com/Iltotore/iron)"],
     "github": "rlemaitre",
-    "twitter": "rlemaitre",
+    "twitter": "rlemaitre_com",
     "otherSnsUrls": []
   },
   {


### PR DESCRIPTION
> [rlemaitre](https://x.com/rlemaitre_com)
[@rlemaitre_com](https://x.com/rlemaitre_com)
Indeed, my account was disabled after my identity was impersonated earlier this year (after the ScalaMatsuri CFP 🙂). That's why I had to re-create a new account
context: https://x.com/rlemaitre_com/status/1799433211275292933